### PR TITLE
Switch all uses of `Result<T, Box<dyn Error>>` to `anyhow::Result<T>`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Turn
 <summary>Ratatui Minimal</summary>
 
 ```rust
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     let mut terminal = setup_terminal()?;
     run(&mut terminal)?;
     restore_terminal(&mut terminal)?;
     Ok(())
 }
 
-fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>, Box<dyn Error>> {
+fn setup_terminal() -> anyhow::Result<Terminal<CrosstermBackend<Stdout>>> {
     let mut stdout = io::stdout();
     enable_raw_mode()?;
     execute!(stdout, EnterAlternateScreen)?;
@@ -20,13 +20,13 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>, Box<dyn Error>
 
 fn restore_terminal(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-) -> Result<(), Box<dyn Error>> {
+) -> anyhow::Result<()> {
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen,)?;
     Ok(terminal.show_cursor()?)
 }
 
-fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<(), Box<dyn Error>> {
+fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> anyhow::Result<()> {
     Ok(loop {
         terminal.draw(|frame| {
             let greeting = Paragraph::new("Hello World!");
@@ -53,8 +53,7 @@ Into
 use crossterm::event::KeyCode;
 use ratatui::widgets::Paragraph;
 use widgetui::*;
-
-use std::error::Error;
+use anyhow::Result;
 
 fn widget(mut frame: ResMut<WidgetFrame>, mut events: ResMut<Events>) -> WidgetResult {
     let size = frame.size();
@@ -67,7 +66,7 @@ fn widget(mut frame: ResMut<WidgetFrame>, mut events: ResMut<Events>) -> WidgetR
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     App::new(100)?.widgets(widget).run()
 }
 ```

--- a/examples/custom_chunk.rs
+++ b/examples/custom_chunk.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-
+use anyhow::Result;
 use ratatui::{
     prelude::{Constraint, Direction, Layout},
     widgets::Paragraph,
@@ -38,7 +37,7 @@ pub fn render(
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     App::new(100)?
         .handle_panics()
         .widgets((chunk_generator, render))

--- a/examples/custom_set.rs
+++ b/examples/custom_set.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-
+use anyhow::Result;
 use ratatui::widgets::Paragraph;
 use widgetui::*;
 
@@ -42,6 +41,6 @@ pub fn CoolSet(app: App) -> App {
     app.widgets(widget).states(CoolState::default())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     App::new(100)?.sets(CoolSet).run()
 }

--- a/examples/custom_state.rs
+++ b/examples/custom_state.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-
+use anyhow::Result;
 use ratatui::widgets::Paragraph;
 use widgetui::*;
 
@@ -34,7 +33,7 @@ pub fn handle_state(
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     App::new(100)?
         .states(CustomState { state: 0 })
         .widgets(handle_state)

--- a/examples/message.rs
+++ b/examples/message.rs
@@ -1,5 +1,6 @@
-use std::{error::Error, time::Duration};
+use std::time::Duration;
 
+use anyhow::Result;
 use ratatui::prelude::{Constraint, Direction, Layout};
 use widgetui::{
     widgets::message::{Message, MessageChunk, MessageState},
@@ -39,7 +40,7 @@ fn my_widget(mut events: ResMut<Events>, mut message: ResMut<MessageState>) -> W
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     App::new(100)?
         .handle_panics()
         .widgets((chunk_builder, my_widget))

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,8 +1,7 @@
+use anyhow::Result;
 use crossterm::event::KeyCode;
 use ratatui::widgets::Paragraph;
 use widgetui::*;
-
-use std::error::Error;
 
 fn widget(mut frame: ResMut<WidgetFrame>, mut events: ResMut<Events>) -> WidgetResult {
     let size = frame.size();
@@ -15,6 +14,6 @@ fn widget(mut frame: ResMut<WidgetFrame>, mut events: ResMut<Events>) -> WidgetR
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     App::new(100)?.widgets(widget).run()
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,11 +2,11 @@ use std::{
     any::{Any, TypeId},
     cell::RefCell,
     collections::HashMap,
-    error::Error,
     ops::Deref,
     time::{Duration, SystemTime},
 };
 
+use anyhow::Result;
 use ratatui::{buffer::Buffer, prelude::Backend};
 
 use crate::{
@@ -30,7 +30,7 @@ pub struct App {
 
 impl App {
     /// Create a new app with the given clock time (in ms)
-    pub fn new(clock: u64) -> Result<Self, Box<dyn Error>> {
+    pub fn new(clock: u64) -> Result<Self> {
         let terminal = setup_terminal()?;
 
         Ok(Self {
@@ -82,7 +82,7 @@ impl App {
     }
 
     /// Run the app, returning an error if any of the functions error out.
-    pub fn run(mut self) -> Result<(), Box<dyn Error>> {
+    pub fn run(mut self) -> Result<()> {
         let result = self.inner_run();
 
         restore_terminal(self.terminal)?;
@@ -90,7 +90,7 @@ impl App {
         result
     }
 
-    fn inner_run(&mut self) -> Result<(), Box<dyn Error>> {
+    fn inner_run(&mut self) -> Result<()> {
         self.terminal.hide_cursor()?;
 
         loop {

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -2,9 +2,9 @@ use std::{
     any::{Any, TypeId},
     cell::RefMut,
     collections::HashMap,
-    error::Error,
 };
 
+use anyhow::Result;
 use ratatui::prelude::Rect;
 
 use crate::*;
@@ -28,10 +28,10 @@ impl Chunks {
 
     /// Returns a rect if the type id is within the chunk,
     /// an error is thrown if it isn't registered.
-    pub fn get_chunk<T: Any>(&self) -> Result<Rect, Box<dyn Error>> {
+    pub fn get_chunk<T: Any>(&self) -> Result<Rect> {
         match self.chunks.get(&TypeId::of::<T>()).cloned() {
             Some(chunk) => Ok(chunk),
-            None => Err(anyhow!("Chunk doesn't exist").into()),
+            None => bail!("Chunk doesn't exist"),
         }
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,8 +1,6 @@
-use std::{
-    error::Error,
-    io::{stdout, Stdout},
-};
+use std::io::{stdout, Stdout};
 
+use anyhow::Result;
 use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -109,7 +107,7 @@ impl WidgetFrame {
 
 /// Sets up the terminal to work with your app
 /// This is run automatically by app.
-pub fn setup_terminal() -> Result<WidgetTerminal, Box<dyn Error>> {
+pub fn setup_terminal() -> Result<WidgetTerminal> {
     enable_raw_mode()?;
     let mut stdout = stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -120,7 +118,7 @@ pub fn setup_terminal() -> Result<WidgetTerminal, Box<dyn Error>> {
 
 /// Takes down the terminal, ensuring that it is all ok.
 /// This is run automatically by the app.
-pub fn restore_terminal(mut terminal: WidgetTerminal) -> Result<(), Box<dyn Error>> {
+pub fn restore_terminal(mut terminal: WidgetTerminal) -> Result<()> {
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     Ok(())
@@ -128,7 +126,7 @@ pub fn restore_terminal(mut terminal: WidgetTerminal) -> Result<(), Box<dyn Erro
 
 /// Resets the terminal in case of a panic.
 /// This is handled automatically if panic handler is enabled.
-pub fn reset_terminal() -> Result<(), Box<dyn Error>> {
+pub fn reset_terminal() -> Result<()> {
     disable_raw_mode()?;
     execute!(stdout(), LeaveAlternateScreen)?;
     Ok(())

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -8,11 +8,12 @@ use crate::{states::States, WidgetFrame};
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    error::Error,
 };
 
+use anyhow::Result;
+
 /// The main result that a widget will always return.
-pub type WidgetResult = Result<(), Box<dyn Error>>;
+pub type WidgetResult = Result<()>;
 
 /// A widget that can be called.
 pub trait Widget {


### PR DESCRIPTION
I tried using this crate in my app, but I found that the error types returned are significantly under-constrained, such that I couldn't use this crate within asynchronous code.
(The error type isn't `: Send`)

It seems like `anyhow` is already brought in as a dependency, only to be used once as `return Err(anyhow!("...").into())` (src/chunks.rs:34)—given that, I decided we might as well change all `Result`s to use `anyhow::Result`, with an import at the top of each file.[^1]  
One alternative would be to use `std::io::Result`, which would slot in correctly in almost every return type across the codebase, or to simply add the constraints necessary for `anyhow::Error` as `Box<dyn Error + Send + Sync + 'static>`.

Unfortunately, it seems all of these changes have the ability to break existing code, and should thus require a semver bump. However; I'm not so sure any real usage of the crate would break---as normal error propagation is done using the `?` operator, which can convert error types to the end users' need.

[^1]: Let me know if you prefer a different style, like defining the alias once at the crate root, or using the full path `anyhow::Result<T>` every time—or feel free to edit the PR yourself ^^.