### PR TITLE
Fix issues in README example and impl_sets! macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ fn widget(mut frame: ResMut<WidgetFrame>, mut events: ResMut<Events>) -> WidgetR
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), impl Error> {
     App::new(100)?.widgets(widget).run()
 }
 ```

--- a/src/set.rs
+++ b/src/set.rs
@@ -47,4 +47,4 @@ impl_sets! {A 0 B 1 C 2 D 3 E 4 F 5 G 6 }
 impl_sets! {A 0 B 1 C 2 D 3 E 4 F 5 G 6 H 7 }
 impl_sets! {A 0 B 1 C 2 D 3 E 4 F 5 G 6 H 7 I 8 }
 impl_sets! {A 0 B 1 C 2 D 3 E 4 F 5 G 6 H 7 I 8 J 9 }
-impl_sets! {A 0 B 1 C 2 D 3 E 4 F 5 G 6 H 7 I 8 J 9 K 0}
+impl_sets! {A 0 B 1 C 2 D 3 E 4 F 5 G 6 H 7 I 8 J 9 K 10}


### PR DESCRIPTION
This pull request addresses two issues:

1. **Update return type in README 'Quickstart' example**
   - The return type of the main function in the README 'Quickstart' example has been updated from `Result<(), Box<dyn Error>>` to `Result<(), impl Error>` to ensure correct compilation.
   - Commit: b0b35027a9e26a82d05bb57ea114c1d0159fcdb7

2. **Update index for 'K' in impl_sets! macro**
   - The index for 'K' in the last `impl_sets!` macro call has been corrected from 0 to 10 to ensure proper indexing for all tuple elements, including 'K'.
   - Commit: 7647e218c2ec67ce5a82e09cb89579559847360e